### PR TITLE
Update Travis local_dir config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install: true
 deploy:
   provider: pages
   skip_cleanup: true
+  local_dir: docs
   github_token: $GH_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep_history: true
   target_branch: gh-pages


### PR DESCRIPTION
Update the Travis-CI configuration to use the `local_dir: docs` option, so that the content of `docs/` is what is used for the **gh-pages** branch and deployment.