### PR TITLE
Fix embedded image indentation

### DIFF
--- a/pages/assemblies/call-to-action.md
+++ b/pages/assemblies/call-to-action.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![Call to action example image](/design-manual/assets/uploads/call-to-action-example.png)
+![Call to action example image](/design-manual/assets/uploads/call-to-action-example.png)

--- a/pages/assemblies/collection.md
+++ b/pages/assemblies/collection.md
@@ -17,4 +17,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![Collection example image](/design-manual/assets/uploads/collection-example.png)
+![Collection example image](/design-manual/assets/uploads/collection-example.png)

--- a/pages/assemblies/combo.md
+++ b/pages/assemblies/combo.md
@@ -15,4 +15,4 @@ featured_image: ""
 1. Page
 2. Topic page
 
-   ![Combo example image](/design-manual/assets/uploads/combo-example.png)
+![Combo example image](/design-manual/assets/uploads/combo-example.png)

--- a/pages/assemblies/content-call-to-action-1.md
+++ b/pages/assemblies/content-call-to-action-1.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![Content image example image](/design-manual/assets/uploads/content-image-example.png)
+![Content image example image](/design-manual/assets/uploads/content-image-example.png)

--- a/pages/assemblies/content-call-to-action.md
+++ b/pages/assemblies/content-call-to-action.md
@@ -18,4 +18,4 @@ featured_image: ""
 4. Getting started product page
 5. Topic page
 
-   ![Content call to action example image](/design-manual/assets/uploads/content_call_to_action-example.png)
+![Content call to action example image](/design-manual/assets/uploads/content_call_to_action-example.png)

--- a/pages/assemblies/content-pull-quote.md
+++ b/pages/assemblies/content-pull-quote.md
@@ -16,4 +16,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![Content pull quote example image](/design-manual/assets/uploads/content-pull-quote-example.png)
+![Content pull quote example image](/design-manual/assets/uploads/content-pull-quote-example.png)

--- a/pages/assemblies/content.md
+++ b/pages/assemblies/content.md
@@ -16,4 +16,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![Content example image](/design-manual/assets/uploads/content-example.png)
+![Content example image](/design-manual/assets/uploads/content-example.png)

--- a/pages/assemblies/cta-form.md
+++ b/pages/assemblies/cta-form.md
@@ -20,4 +20,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/cta-form-example.png)
+![](/design-manual/assets/uploads/cta-form-example.png)

--- a/pages/assemblies/curated-content.md
+++ b/pages/assemblies/curated-content.md
@@ -19,4 +19,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/curated-content-example.png)
+![](/design-manual/assets/uploads/curated-content-example.png)

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -19,4 +19,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/curated-links-example.png)
+![](/design-manual/assets/uploads/curated-links-example.png)

--- a/pages/assemblies/curated-products.md
+++ b/pages/assemblies/curated-products.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/curated-products-example.png)
+![](/design-manual/assets/uploads/curated-products-example.png)

--- a/pages/assemblies/dynamic-content-list.md
+++ b/pages/assemblies/dynamic-content-list.md
@@ -19,4 +19,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/dynamic-content-list-example.png)
+![](/design-manual/assets/uploads/dynamic-content-list-example.png)

--- a/pages/assemblies/dynamic-content.md
+++ b/pages/assemblies/dynamic-content.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/dynamic-content-example.png)
+![](/design-manual/assets/uploads/dynamic-content-example.png)

--- a/pages/assemblies/eloqua-form-embed.md
+++ b/pages/assemblies/eloqua-form-embed.md
@@ -19,4 +19,4 @@ featured_image: ""
 5. Getting Started product page
 6. Topics page
 
-   ![](/design-manual/assets/uploads/eloqua-form-embed-example.png)
+![](/design-manual/assets/uploads/eloqua-form-embed-example.png)

--- a/pages/assemblies/events-hero.md
+++ b/pages/assemblies/events-hero.md
@@ -20,4 +20,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/events-hero-example.png)
+![](/design-manual/assets/uploads/events-hero-example.png)

--- a/pages/assemblies/events-list.md
+++ b/pages/assemblies/events-list.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/events-list-example.png)
+![](/design-manual/assets/uploads/events-list-example.png)

--- a/pages/assemblies/expandable-product-groups.md
+++ b/pages/assemblies/expandable-product-groups.md
@@ -17,4 +17,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/expandable-product-groups-example.png)
+![](/design-manual/assets/uploads/expandable-product-groups-example.png)

--- a/pages/assemblies/featured-articles.md
+++ b/pages/assemblies/featured-articles.md
@@ -17,4 +17,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/featured-articles-example.png)
+![](/design-manual/assets/uploads/featured-articles-example.png)

--- a/pages/assemblies/featured-evangelists.md
+++ b/pages/assemblies/featured-evangelists.md
@@ -18,4 +18,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/featured-evangelists-example.png)
+![](/design-manual/assets/uploads/featured-evangelists-example.png)

--- a/pages/assemblies/featured-resources.md
+++ b/pages/assemblies/featured-resources.md
@@ -19,4 +19,4 @@ featured_image: ""
 5. Getting started product page
 6. Topic page
 
-   ![](/design-manual/assets/uploads/featured-resources-example.png)
+![](/design-manual/assets/uploads/featured-resources-example.png)


### PR DESCRIPTION
Remove the indentations of the embedded images that were causing them to be part of the ordered lists.

This also fixes the issue where the images were not rendering in the Admin UI.