### PR TITLE
Add file type to Netlify CMS commit messages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -7,9 +7,9 @@ backend:
   branch: master # Branch to update (master by default)
   squash_merges: true
   commit_messages:
-    create: Create "{{slug}}" {{type}}
-    update: Update "{{slug}}" {{type}}
-    delete: Delete "{{slug}}" {{type}}
+    create: Create "{{slug}}" "{{type}}"
+    update: Update "{{slug}}" "{{type}}"
+    delete: Delete "{{slug}}" "{{type}}"
     uploadMedia: Upload "{{path}}"
     deleteMedia: Delete "{{path}}"
 subfolder: "/design-manual/"


### PR DESCRIPTION
Add file type to the Netlify commit messages to distinguish between navigations and pages.

`type: "navigation"` or `type: "page"`