### PR TITLE
Rename references of Master to Main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ deploy:
   keep_history: true
   target_branch: gh-pages
   on:
-    branch: master
+    branch: main
 after_deploy:
   - scripts/./release.sh minor  

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -4,7 +4,7 @@
 backend:
   name: git-gateway # Netlify’s Git Gateway connects to Git provider’s API
   repo: redhat-developer/design-manual
-  branch: master # Branch to update (master by default)
+  branch: main # Branch to update (main by default)
   squash_merges: true
   commit_messages:
     create: Create "{{slug}}" "{{type}}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,8 +1,8 @@
-echo "Checkout Master branch"
-git checkout master
+echo "Checkout Main branch"
+git checkout main
 
-echo "Pull latest from master"
-git pull --rebase origin master
+echo "Pull latest from main"
+git pull --rebase origin main
 
 echo "Build site"
 gulp build

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,11 +4,11 @@ then
   exit 1;
 fi
 
-echo "Checkout Master branch"
-git checkout master
+echo "Checkout Main branch"
+git checkout main
 
-echo "Pull latest from master"
-git pull --rebase origin master
+echo "Pull latest from main"
+git pull --rebase origin main
 
 echo "Update NPM Version"
 VERSION=${1?Error: delineate major, minor, patch or prerelease}
@@ -17,8 +17,8 @@ npm version "$VERSION"
 echo "Update Changelog"
 gren release --data-source=commits && gren changelog --override
 
-echo "Commit Changelog and push to master"
+echo "Commit Changelog and push to main"
 git add --all && git commit -m "Update Changelog"
 
-echo "Push to Master"
-git push origin master
+echo "Push to Main"
+git push origin main


### PR DESCRIPTION
# Rename references of Master to Main

## Description of changes
After renaming the `Master` branch to `Main`, the various scripts also needed to be updated. All references to `Master` have been replaced with `Main`
