### PR TITLE
Create github-tag-actions.yml

### DIFF
--- a/.github/workflows/github-tag-actions.yml
+++ b/.github/workflows/github-tag-actions.yml
@@ -1,0 +1,20 @@
+name: Bump version
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Github Tag Bump
+      uses: anothrNick/github-tag-action@1.22.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: false
+        DEFAULT_BUMP: minor
+        RELEASE_BRANCHES: main


### PR DESCRIPTION
# Create github-tag-actions.yml

## Description of changes
Add a GitHub Action workflow for automatically bumping the GitHub Tags. All commits are considered minor revisions, unless otherwise stated.

Links: https://github.com/marketplace/actions/github-tag-bump

> Bumping
> Manual Bumping: Any commit message that includes #major, #minor, or #patch will trigger the respective version bump. If two or more are present, the highest-ranking one will take precedence.
> Automatic Bumping: If no #major, #minor or #patch tag is contained in the commit messages, it will bump whichever DEFAULT_BUMP is set to (which is minor by default). Disable this by setting DEFAULT_BUMP to none.