### PR TITLE
Update github-tag-actions.yml

### DIFF
--- a/.github/workflows/github-tag-actions.yml
+++ b/.github/workflows/github-tag-actions.yml
@@ -18,3 +18,4 @@ jobs:
         WITH_V: false
         DEFAULT_BUMP: minor
         RELEASE_BRANCHES: main
+        INITIAL_VERSION: 2.26.1 


### PR DESCRIPTION
# Update github-tag-actions.yml

## Description of changes
Set `INITIAL_VERSION` to `2.26.1` in order to continue current release numbering.
