### PR TITLE
fix: add automated tag creation

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,3 +24,12 @@ jobs:
           MERGE_RETRY_SLEEP: 10000
           UPDATE_LABELS: "Ready to merge"
           UPDATE_METHOD: merge
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump tag version
+        uses: anothrNick/github-tag-action@1.22.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: false


### PR DESCRIPTION
## Description of changes
Update the `automerge.yml` GitHub Action to include a step for automatically creating a new tag. This will then start up the `Create release` action, bumping the release number.
