### PR TITLE
fix: Start moving build scripts to Github Actions

### DIFF
--- a/.github/workflows/gulp-build.yml
+++ b/.github/workflows/gulp-build.yml
@@ -1,0 +1,35 @@
+name: Gulp
+on: [pull-request]
+env:
+  CI: true
+  NODE: 12.18.x
+
+jobs:
+  gulp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Set Node version
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ env.NODE }}"
+
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Gulp CLI
+        run: npm install gulp-cli -g
+
+      - name: Run Deployment
+        run: npm run deployment

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -1,0 +1,45 @@
+name: Site Build
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  Assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1.40.0
+        with:
+          ruby-version: 2.6.3
+          bundler-cache: true
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          check-latest: true
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Gulp CLI
+        run: npm install gulp-cli -g
+
+      - name: Copy Files
+        run: gulp copyStatic
+      - name: Minimize Images
+        run: gulp minimizeImages
+      - name: Build JavaScript
+        run: gulp jsDev
+      - name: Build CSS
+        run: gulp cssDev
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.5.7
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs # The folder the action should deploy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "design-manual",
-  "version": "2.43.2",
+  "version": "2.44.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1170,12 +1170,6 @@
       "requires": {
         "inherits": "~2.0.0"
       }
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -3477,17 +3471,6 @@
         "globule": "^1.0.0"
       }
     },
-    "generate-changelog": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/generate-changelog/-/generate-changelog-1.8.0.tgz",
-      "integrity": "sha512-msgpxeB75Ziyg3wGsZuPNl7c5RxChMKmYcAX5obnhUow90dBZW3nLic6nxGtst7Bpx453oS6zAIHcX7F3QVasw==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.0.6",
-        "commander": "^2.9.0",
-        "github-url-from-git": "^1.4.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -3646,12 +3629,6 @@
         "require-yaml": "0.0.1",
         "valid-url": "^1.0.9"
       }
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-manual",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "Documentation and source files for RHD brand standards & design systems.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-manual",
-  "version": "2.43.2",
+  "version": "2.44.0",
   "description": "Documentation and source files for RHD brand standards & design systems.",
   "main": "index.js",
   "engines": {
@@ -65,8 +65,5 @@
     "stylelint-value-no-unknown-custom-properties": "3.0.0",
     "imagemin-mozjpeg": "8.0.0",
     "imagemin-pngquant": "8.0.0"
-  },
-  "devDependencies": {
-    "generate-changelog": "1.8.0"
   }
 }


### PR DESCRIPTION
## Description of changes

Start the process of moving build scripts from Travis-CI to GitHub Actions.
- Configure a `gulp-build.yml` file to execute NPM scripts on pull requests
- Remove branch and pull request builds from the Travis-CI process