### PR TITLE
Set deploy-preview to use production environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,10 +17,10 @@
 # Deploy Preview context: all deploys generated from a pull/merge request will
 # inherit these settings.
 [context.deploy-preview]
-  environment = { JEKYLL_ENV = "development" }
+  environment = { JEKYLL_ENV = "production" }
   base = "/"
   publish = "docs/"
-  command = "npm run build"
+  command = "npm run build-netlify"
 
 # If skip_processing = true, all other settings are ignored
 [build.processing]


### PR DESCRIPTION
## Description of changes
Set the `deploy-preview` Netlify build to use the production environment configuration in order to render the site without the `/design-manual` path.