### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,5 @@
 name: Automatically merge PRs
+
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -7,6 +8,7 @@ on:
   check_suite:
     types: [completed]
     status: success
+
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -1,14 +1,19 @@
 name: Bump tag version
+
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
         with:
           fetch-depth: '0'
       - name: Bump tag version and push
@@ -18,7 +23,7 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: false
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: Update changelog
         uses: ScottBrenner/generate-changelog-action@1.0.0
         id: Changelog
@@ -30,10 +35,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: |
             Changes in this release:
             ${{ steps.Changelog.outputs.changelog }}
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -16,10 +16,11 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump tag version and push
-        uses: anothrNick/github-tag-action@1.22.0
+        uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
+          DRY_RUN: true
           WITH_V: false
       - name: Checkout code
         uses: actions/checkout@v2.3.2
@@ -39,5 +40,7 @@ jobs:
           body: |
             Changes in this release:
             ${{ steps.Changelog.outputs.changelog }}
+            Changes were made by:
+            ${{ github.actor }}
           draft: true
           prerelease: false

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches: [main]
-    types: [opened, closed]
+    types: [opened, synchronize, closed]
 
 jobs:
   build:
@@ -33,6 +33,8 @@ jobs:
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
+        run: |
+          git fetch --prune --unshallow --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
@@ -42,6 +44,6 @@ jobs:
             Changes in this release:
             ${{ steps.tag_and_prepare_release.outputs.tag }}
             Changes were made by:
-            @${{ github.actor }}
+            ${{ github.actor }}
           draft: true
           prerelease: false

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -40,10 +40,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
-          body: |
-            Changes in this release:
-            ${{ steps.tag_and_prepare_release.outputs.tag }}
-            Changes were made by:
-            ${{ github.actor }}
+          body:
           draft: true
           prerelease: false

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
+          tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: |
             Changes in this release:

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -30,11 +30,11 @@ jobs:
         id: Changelog
         env:
           REPO: ${{ github.repository }}
+      - run: |
+          git fetch --prune --unshallow --tags
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest
-        run: |
-          git fetch --prune --unshallow --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     branches: [main]
+    types: [opened, closed]
 
 jobs:
   build:
@@ -39,8 +40,8 @@ jobs:
           release_name: ${{ github.ref }}
           body: |
             Changes in this release:
-            ${{ steps.Changelog.outputs.changelog }}
+            ${{ steps.tag_and_prepare_release.outputs.tag }}
             Changes were made by:
-            ${{ github.actor }}
+            @${{ github.actor }}
           draft: true
           prerelease: false

--- a/.github/workflows/bump-tag-version.yml
+++ b/.github/workflows/bump-tag-version.yml
@@ -6,7 +6,6 @@ on:
       - main
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -1,0 +1,21 @@
+name: Release-Notes-Preview
+
+on:
+  pull_request:
+    branches: [ main ]
+  issue_comment:
+    types: [ edited ]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.2
+    - run: |
+        git fetch --prune --unshallow --tags
+    - uses: snyk/release-notes-preview@v1.6.1
+      with:
+        releaseBranch: main
+      env:
+        GITHUB_PR_USERNAME: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-          check-latest: true
+          check-latest: version
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
   Assets:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,15 @@ If you find an issue, please [submit an issue](https://github.com/redhat-develop
 If you wish to contribute code to this project, you should follow our [Setup](guides/SETUP.md) and [Development](guides/DEVELOPMENT.md) guides, and then raise any changes via pull requests.
 
 ----
+## Pull Requests
+Pull requests must follow the Semantic Release formatting (i.e. `feat`, `fix`, `patch`).
+
+```bash
+fix: Update sidebar styling
+```
+
+If you do not use one of these prefixes, then your PR will not automatically generate release notes. Without release notes, PRs will not be merged.
+
+----
 __Any and all changes must be approved by members of the developers.redhat.com team.__
 


### PR DESCRIPTION
## Description of changes
Update various GitHub Actions. Set releases to be created as drafts when a PR is created, or code merged directly to `Main`. Add ability for release notes to be previewed in the PR.