### PR TITLE
fix: Update Assembly creation template

### DIFF
--- a/_layouts/assemblies.html
+++ b/_layouts/assemblies.html
@@ -23,6 +23,11 @@ layout: compress
             <div class="pf-l-grid__item pf-m-12-col" id="main">
               <h1>{{ page.title }}</h1>
               <blockquote>{% include page-intro.html %}</blockquote>
+              {% if page.labels and page.labels != '' %}
+                <ul>
+                  <li>{{ page.labels }}</li>
+                </ul>
+              {% endif %}
               {{ content }}
             </div>
           </div>

--- a/_layouts/assemblies.html
+++ b/_layouts/assemblies.html
@@ -26,11 +26,11 @@ layout: compress
               {% endif %}
               <h1>{{ page.title }}</h1>
               <blockquote>{% include page-intro.html %}</blockquote>
+              {% if page.labels %}
               <ul>
-                {% if page.labels %}
-                  <li>{{ page.labels | markdownify | remove: '<p>' | remove: '</p>' }}</li>
-                {% endif %}
+                <li>{{ page.labels | markdownify | remove: '<p>' | remove: '</p>' }}</li>
               </ul>
+              {% endif %}
               {{ content }}
             </div>
           </div>

--- a/_layouts/assemblies.html
+++ b/_layouts/assemblies.html
@@ -21,13 +21,16 @@ layout: compress
         <section class="pf-c-page__main-section pf-m-light pf-m-fill">
           <div class="pf-l-grid pf-c-content">
             <div class="pf-l-grid__item pf-m-12-col" id="main">
+              {% if page.featured_image and page.featured_image != '' %}
+                {{ page.featured_image }}
+              {% endif %}
               <h1>{{ page.title }}</h1>
               <blockquote>{% include page-intro.html %}</blockquote>
-              {% if page.labels and page.labels != '' %}
-                <ul>
-                  <li>{{ page.labels }}</li>
-                </ul>
-              {% endif %}
+              <ul>
+                {% if page.labels %}
+                  <li>{{ page.labels | markdownify | remove: '<p>' | remove: '</p>' }}</li>
+                {% endif %}
+              </ul>
               {{ content }}
             </div>
           </div>

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -387,7 +387,6 @@ collections: # A list of collections the CMS should be able to edit
     fields:
       - label: "Custom CSS for Assembly examples"
         name: "custom_css"
-        widget: "string"
         default: "assemblies"
         required: true
         widget: "hidden"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -305,12 +305,15 @@ collections: # A list of collections the CMS should be able to edit
         name: "active_nav"
         widget: "string"
         hint: "Available options: Content_types"
-        default: ""
         required: true
       - label: "Intro Paragraph"
         name: "intro_paragraph"
         widget: "markdown"
         required: false
+      - label: "Body"
+        name: "body"
+        widget: "markdown"
+        required: true
       - label: "Custom JS File"
         name: "custom_js"
         widget: "string"
@@ -323,10 +326,6 @@ collections: # A list of collections the CMS should be able to edit
         default: ""
         hint: "Add a custom CSS file to the page."
         required: false
-      - label: "Body"
-        name: "body"
-        widget: "markdown"
-        required: true
   - name: "page"
     label: "Overviews"
     folder: "pages"
@@ -427,14 +426,24 @@ collections: # A list of collections the CMS should be able to edit
           - { label: "Unreleased", value: "unreleased" }
           - { label: "Development", value: "development" }
         required: true
+      - label: "Available in the following content types: "
+        hidden: false
+        name: "label"
+        widget: "select"
+        hint: "Let the user know where they can find this Assembly."
+        options: ["Articles", "Pages", "Events", "Products", "Topics"]
+        min: 1
+        required: false
       - label: "Intro Paragraph"
         name: "intro_paragraph"
-        widget: "markdown"
+        widget: "text"
         required: false
+        hint: "Plain text, no markdown or code."
       - label: "Body"
         name: "body"
         widget: "markdown"
         required: true
+        hint: "Use the + button to add Images or YouTube videos to the page."
       - label: "Featured Image"
         name: "featured_image"
         widget: "image"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -385,7 +385,7 @@ collections: # A list of collections the CMS should be able to edit
     slug: "{{slug}}"
     type: "page"
     fields:
-      - label: "Custom CSS File"
+      - label: "Custom CSS for Assembly examples"
         name: "custom_css"
         widget: "string"
         default: "assemblies"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -437,7 +437,11 @@ collections: # A list of collections the CMS should be able to edit
         widget: "select"
         multiple: true
         hint: "Let the user know where they can find this Assembly."
-        options: ["Articles", "Pages", "Events", "Products", "Topics"]
+        options:
+          - { label: "Articles", value: "articles" }
+          - { label: "Pages", value: "pages" }
+          - { label: "Events", value: "Products" }
+          - { label: "Topics", value: "topics" }
         min: 1
         required: false
       - label: "Intro Paragraph"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -440,7 +440,7 @@ collections: # A list of collections the CMS should be able to edit
         options:
           - { label: "Articles", value: "articles" }
           - { label: "Pages", value: "pages" }
-          - { label: "Events", value: "Products" }
+          - { label: "Events", value: "products" }
           - { label: "Topics", value: "topics" }
         min: 1
         required: false

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -385,6 +385,12 @@ collections: # A list of collections the CMS should be able to edit
     slug: "{{slug}}"
     type: "page"
     fields:
+      - label: "Custom CSS File"
+        name: "custom_css"
+        widget: "string"
+        default: "assemblies"
+        required: true
+        widget: "hidden"
       - label: "Layout"
         name: "layout"
         widget: "hidden"
@@ -430,6 +436,7 @@ collections: # A list of collections the CMS should be able to edit
         hidden: false
         name: "label"
         widget: "select"
+        multiple: true
         hint: "Let the user know where they can find this Assembly."
         options: ["Articles", "Pages", "Events", "Products", "Topics"]
         min: 1

--- a/admin/index.html
+++ b/admin/index.html
@@ -13,33 +13,43 @@
   <body>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
     <script>
-      CMS.registerEditorComponent({
-        // Internal id of the component
-        id: "youtube",
-        // Visible label
-        label: "Youtube",
-        // Fields the user need to fill out when adding an instance of the component
-        fields: [{name: 'id', label: 'Youtube Video ID', widget: 'string'}],
-        // Pattern to identify a block as being an instance of this component
-        pattern: /^youtube (\S+)$/,
-        // Function to extract data elements from the regexp match
-        fromBlock: function(match) {
-          return {
-            id: match[1]
-          };
-        },
-        // Function to create a text block from an instance of this component
-        toBlock: function(obj) {
-          return 'youtube ' + obj.id;
-        },
-        // Preview output for this component. Can either be a string or a React component
-        // (component gives better render performance)
-        toPreview: function(obj) {
-          return (
-            '<img src="http://img.youtube.com/vi/' + obj.id + '/maxresdefault.jpg" alt="Youtube Video"/>'
-          );
-        }
-      });
+    const previewStyles = `
+      html,
+      body {
+        color: #151515;
+        font-size: 16px;
+        font-family: "Red Hat Text", sans-serif;
+      }
+      h1 {
+        font-weight: bold;
+        font-size: 32px;
+      }
+      h1, h2, h3, h4, h5, h6 {
+        font-family: "Red Hat Display", sans-serif;
+      }
+      p {
+        font-family: "Red Hat Text", sans-serif;
+      }
+    `;
+    CMS.registerEditorComponent({
+      id: "youtube",
+      label: "Youtube",
+      fields: [{name: 'id', label: 'Youtube Video ID'}],
+      pattern: /^{{<\s?youtube (\S+)\s?>}}/,
+      fromBlock: function(match) {
+        return {
+          id: match[1]
+        };
+      },
+      toBlock: function(obj) {
+        return '{{< youtube ' + obj.id + ' >}}';
+      },
+      toPreview: function(obj) {
+        return (
+          '<img src="http://img.youtube.com/vi/' + obj.id + '/maxresdefault.jpg" alt="Youtube Video"/>'
+        );
+      }
+    });
       </script>
   </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,5 +12,34 @@
   </head>
   <body>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script>
+      CMS.registerEditorComponent({
+        // Internal id of the component
+        id: "youtube",
+        // Visible label
+        label: "Youtube",
+        // Fields the user need to fill out when adding an instance of the component
+        fields: [{name: 'id', label: 'Youtube Video ID', widget: 'string'}],
+        // Pattern to identify a block as being an instance of this component
+        pattern: /^youtube (\S+)$/,
+        // Function to extract data elements from the regexp match
+        fromBlock: function(match) {
+          return {
+            id: match[1]
+          };
+        },
+        // Function to create a text block from an instance of this component
+        toBlock: function(obj) {
+          return 'youtube ' + obj.id;
+        },
+        // Preview output for this component. Can either be a string or a React component
+        // (component gives better render performance)
+        toPreview: function(obj) {
+          return (
+            '<img src="http://img.youtube.com/vi/' + obj.id + '/maxresdefault.jpg" alt="Youtube Video"/>'
+          );
+        }
+      });
+      </script>
   </body>
 </html>

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -11,6 +11,7 @@ intro_paragraph: >-
   be linked off from on a page (as opposed to a collection assembly
   automatically bringing links in based on a keyword).
 featured_image: ""
+custom_css: [assemblies]
 label:
 ---
 

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -10,11 +10,12 @@ intro_paragraph: >-
   The curated links assembly can be used as a way to manually select content to
   be linked off from on a page (as opposed to a collection assembly
   automatically bringing links in based on a keyword).
-
-
-  <div><iframe width="560" height="315" src="https://www.youtube.com/embed/dNeGJ4GV50I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 featured_image: ""
+label:
 ---
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dNeGJ4GV50I" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## What content types can I add this assembly to?
 
 View example usage of the curated links assembly in production on the [Quarkus product page](https://developers.redhat.com/products/quarkus/getting-started) and the [Serverless topic page](https://developers.redhat.com/topics/serverless-architecture)

--- a/styles/custom/assemblies.scss
+++ b/styles/custom/assemblies.scss
@@ -1,0 +1,4 @@
+iframe {
+  width: 560px;
+  height: 315px;
+}


### PR DESCRIPTION
## Description of changes
Update the Assembly creation template in the CMS with the following changes:

- Set "Intro Paragraph" to be a plain text field. This will prevent code from being added to the frontmatter, which could break the site.
- Add a field input hint to the "Body" for embedding YouTube videos.
- Add a YouTube embed ability to the "Body", requiring only a link, rather than the entire `<iframe>` code.
- Add a new label dropdown for letting users know where they can find the examples in the Drupal environment.
