### PR TITLE
fix: Add multi-column layout for Assembly examples

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -448,6 +448,13 @@ collections: # A list of collections the CMS should be able to edit
         widget: "text"
         required: false
         hint: "Plain text, no markdown or code."
+      - label: "Content"
+        name: "content"
+        widget: "list"
+        hint: "Select the layout types that you wish to use on the page. Each layout can only be used once."
+        fields:
+          - { label: "Single Column Layout", name: "single-column", widget: "markdown", required: false }
+          - { label: "Two Column Layout", name: "two-column", widget: "markdown", required: false }
       - label: "Body"
         name: "body"
         widget: "markdown"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -457,13 +457,19 @@ collections: # A list of collections the CMS should be able to edit
             name: "single-column"
             widget: "object"
             fields:
-              - { label: "Single Column", name: "single-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-12-col'> [ add content here ] </div></div>", required: false }
+              - { label: "Single Column", name: "single-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-12-col'> [ add content here ] </div></div>", hint: "Switch to Markdown view for best results", required: false }
           - label: "Two Column Layout"
             name: "two-column"
             widget: "object"
             fields:
               - { label: "Two Column", name: "two-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-6-col'> [ add content here ] </div>
-  <div class='pf-l-grid__item pf-m-6-col'> [ add content here ] </div></div>", required: false }
+  <div class='pf-l-grid__item pf-m-6-col'> [ add content here ] </div></div>", hint: "Switch to Markdown view for best results", required: false }
+          - label: "Three Column Layout"
+            name: "three-column"
+            widget: "object"
+            fields:
+              - { label: "Three Column", name: "three-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-4-col'> [ add content here ] </div>
+  <div class='pf-l-grid__item pf-m-4-col'> [ add content here ] </div><div class='pf-l-grid__item pf-m-4-col'> [ add content here ] </div></div>", hint: "Switch to Markdown view for best results", required: false }
       - label: "Body"
         name: "body"
         widget: "markdown"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -452,9 +452,17 @@ collections: # A list of collections the CMS should be able to edit
         name: "content"
         widget: "list"
         hint: "Select the layout types that you wish to use on the page. Each layout can only be used once."
-        fields:
-          - { label: "Single Column Layout", name: "single-column", widget: "markdown", required: false }
-          - { label: "Two Column Layout", name: "two-column", widget: "markdown", required: false }
+        types:
+          - label: "Single Column Layout"
+            name: "single-column"
+            widget: "object"
+            fields:
+              - { label: "Text", name: "single-column-text", widget: "markdown", required: false }
+          - label: "Two Column Layout"
+            name: "two-column"
+            widget: "object"
+            fields:
+              - { label: "Text", name: "two-column-text", widget: "markdown", required: false }
       - label: "Body"
         name: "body"
         widget: "markdown"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -448,7 +448,7 @@ collections: # A list of collections the CMS should be able to edit
         widget: "text"
         required: false
         hint: "Plain text, no markdown or code."
-      - label: "Content"
+      - label: "Advanced Content Creation"
         name: "content"
         widget: "list"
         hint: "Select the layout types that you wish to use on the page. Each layout can only be used once."
@@ -457,16 +457,17 @@ collections: # A list of collections the CMS should be able to edit
             name: "single-column"
             widget: "object"
             fields:
-              - { label: "Text", name: "single-column-text", widget: "markdown", required: false }
+              - { label: "Single Column", name: "single-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-12-col'> [ add content here ] </div></div>", required: false }
           - label: "Two Column Layout"
             name: "two-column"
             widget: "object"
             fields:
-              - { label: "Text", name: "two-column-text", widget: "markdown", required: false }
+              - { label: "Two Column", name: "two-column-text", widget: "markdown", default: "<div class='pf-l-grid'><div class='pf-l-grid__item pf-m-6-col'> [ add content here ] </div>
+  <div class='pf-l-grid__item pf-m-6-col'> [ add content here ] </div></div>", required: false }
       - label: "Body"
         name: "body"
         widget: "markdown"
-        required: true
+        required: false
         hint: "Use the '+' button to add Images or Code Blocks."
   - name: "layouts"
     label: "Layouts"


### PR DESCRIPTION
## Description of changes
Add multi-column layout options for Assembly example pages using the `object` widget in the CMS.