### PR TITLE
fix: simplify video and image uploads for Assembly examples

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -432,17 +432,23 @@ collections: # A list of collections the CMS should be able to edit
           - { label: "Development", value: "development" }
         required: true
       - label: "Featured Video"
-        name: "video"
-        widget: "object"
-        fields:
-          - { label: "YouTube video", name: "youtube_video", widget: "string", hint: "Add the YouTube video ID here (do not include https://www.youtube.com/embed/).", required: false }
-          - { label: "Video title", name: "video-title", widget: "string", required: false }
+        name: "youtube_video"
+        widget: "string"
+        hint: "Add the YouTube video ID here (do not include https://www.youtube.com/embed/)."
+        required: false
+      - label: "Featured Video Title"
+        name: "video-title"
+        widget: "string"
+        required: false
       - label: "Featured Image"
-        name: "image"
-        widget: "object"
-        fields:
-          - { label: "Image", name: "featured_image-file", widget: "image", required: false }
-          - { label: "Alt text", name: "featured_image-text", widget: "string", hint: "Describe what this is an image of. This will appear if the image does not render.", required: false }
+        name: "featured_image-file"
+        widget: "image"
+        required: false
+      - label: "Featured Image Alt Text"
+        name: "featured_image-text"
+        widget: "string"
+        hint: "Describe what this is an image of. This will appear if the image does not render."
+        required: false
       - label: "Intro Paragraph"
         name: "intro_paragraph"
         widget: "text"

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -10,13 +10,11 @@ active_nav: Assemblies
 permalink: /assemblies/curated-links
 featured_image-text: This is a rich text example image
 status: released
-video:
-  youtube_video: G8Zn9SDmA3M
-  video-title: RHD Curated Links Creation Demo
+youtube_video: G8Zn9SDmA3M
+video-title: RHD Curated Links Creation Demo
 intro_paragraph: The curated links assembly can be used as a way to manually
   select content to be linked off from on a page (as opposed to a collection
   assembly automatically bringing links in based on a keyword).
-youtube_video: dNeGJ4GV50I
 featured_image-file: /assets/uploads/rich-text-example.png
 ---
 


### PR DESCRIPTION
## Description of changes
Simplify the **Featured Video** and **Featured Image** uploads from objects to strings in order to prevent indentation in the FrontMatter.