### PR TITLE
fix: placement of featured image

### DIFF
--- a/_layouts/assemblies.html
+++ b/_layouts/assemblies.html
@@ -34,6 +34,7 @@ layout: compress
                 title="{{ page.video-title }}">
               </iframe>  
               {% endif %}
+              {{ content }}
               {% if page.featured_image-file and page.featured_image-file != '' %}
                 {% if jekyll.environment == 'development' %}
                   <img src="{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
@@ -41,7 +42,6 @@ layout: compress
                   <img src="{{ site.baseurl }}{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
                 {% endif %}
               {% endif %}
-              {{ content }}
             </div>
           </div>
         </section>

--- a/_layouts/create.html
+++ b/_layouts/create.html
@@ -35,6 +35,7 @@ layout: compress
                   title="{{ page.video-title }}">
                 </iframe>  
               {% endif %}
+              {{ content }}
               {% if page.featured_image-file and page.featured_image-file != '' %}
                 {% if jekyll.environment == 'development' %}
                   <img src="{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
@@ -42,7 +43,6 @@ layout: compress
                   <img src="{{ site.baseurl }}{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
                 {% endif %}
               {% endif %}
-              {{ content }}
               <div class="rhddx-m-float">
                 {% if page.title == 'Create Overview / Getting Started' %}
                 <a class="pf-c-button pf-m-primary rhddx-c-button rhddx-m-edit" href="https://redhat-developer-design-manual.netlify.app/admin/#/collections/page/entries/create" title="Edit this page">

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -15,7 +15,7 @@ video-title: RHD Curated Links Creation Demo
 intro_paragraph: The curated links assembly can be used as a way to manually
   select content to be linked off from on a page (as opposed to a collection
   assembly automatically bringing links in based on a keyword).
-featured_image-file: /assets/uploads/rich-text-example.png
+featured_image-file:
 ---
 
 ## What content types can I add this assembly to?


### PR DESCRIPTION
## Description of changes
- Move the **Featured Image** field to the bottom of the page.
- Delete the Featured Image from the _Curated Links_ page.