### PR TITLE
fix: remove duplicate widget variables

### DIFF
--- a/_layouts/assemblies.html
+++ b/_layouts/assemblies.html
@@ -35,13 +35,6 @@ layout: compress
               </iframe>  
               {% endif %}
               {{ content }}
-              {% if page.featured_image-file and page.featured_image-file != '' %}
-                {% if jekyll.environment == 'development' %}
-                  <img src="{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
-                {% elsif jekyll.environment == 'production' %}  
-                  <img src="{{ site.baseurl }}{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
-                {% endif %}
-              {% endif %}
             </div>
           </div>
         </section>

--- a/_layouts/create.html
+++ b/_layouts/create.html
@@ -36,13 +36,6 @@ layout: compress
                 </iframe>  
               {% endif %}
               {{ content }}
-              {% if page.featured_image-file and page.featured_image-file != '' %}
-                {% if jekyll.environment == 'development' %}
-                  <img src="{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
-                {% elsif jekyll.environment == 'production' %}  
-                  <img src="{{ site.baseurl }}{{ page.featured_image-file }}" alt="{{ page.featured_image-text }}"></img>
-                {% endif %}
-              {% endif %}
               <div class="rhddx-m-float">
                 {% if page.title == 'Create Overview / Getting Started' %}
                 <a class="pf-c-button pf-m-primary rhddx-c-button rhddx-m-edit" href="https://redhat-developer-design-manual.netlify.app/admin/#/collections/page/entries/create" title="Edit this page">

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,13 +1,28 @@
 html,
 body {
+  font-family: "Red Hat Text", sans-serif;
   font-size: 16px;
-  font-family: var(--font-family-text);
 }
+
+h1 {
+  font-size: 32px;
+  font-weight: 700;
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--font-family-headings);
+  font-family: "Red Hat Display", sans-serif;
+}
+
+p {
+  font-family: "Red Hat Text", sans-serif;
+}
+
+img {
+  width: 560px;
+  height: 315px;
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -6,9 +6,9 @@
     <title>Red Hat Developer Design Manual Admin Portal</title>
     <link href="https://fonts.googleapis.com/css?family=Red+Hat+Display:500,700|Red+Hat+Text:400,500&display=swap" rel="stylesheet">
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    <!-- <script>
+    <script>
       CMS.registerPreviewStyle("/admin.css");
-    </script> -->
+    </script>
   </head>
   <body>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>

--- a/pages/assemblies/curated-links.md
+++ b/pages/assemblies/curated-links.md
@@ -1,21 +1,16 @@
 ---
-section: Create
-video-title: RHD Curated Links Creation Demo
-custom_css:
-  - assemblies
+custom_css: [assemblies]
 layout: create
 category: create
+section: Create
 title: Curated links
 active_nav: Assemblies
 permalink: /assemblies/curated-links
-featured_image-text: This is a rich text example image
 status: released
 youtube_video: G8Zn9SDmA3M
 video-title: RHD Curated Links Creation Demo
-intro_paragraph: The curated links assembly can be used as a way to manually
-  select content to be linked off from on a page (as opposed to a collection
-  assembly automatically bringing links in based on a keyword).
-featured_image-file:
+intro_paragraph: >
+  The curated links assembly can be used as a way to manually select content to be linked off from on a page (as opposed to a collection assembly automatically bringing links in based on a keyword).
 ---
 
 ## What content types can I add this assembly to?
@@ -39,7 +34,7 @@ As with most assemblies, you can add a title. Then, there are two routes for get
 
 We can display curated links in three different formats using 'Display styles'.
 
-* Display styles: **\--none---**
+* Display styles: **--none--**
 
   ![curated link without display styles](/design-manual/assets/uploads/curated-link.png)
 * Display styles: **horizontal navigation**


### PR DESCRIPTION
## Description of changes
- Remove the duplicate `video-title` from page frontmatter, which resulted in rendering errors.
- Clean up **curated-links** page so that frontmatter config matches the `.yml` template.
- Remove `featured-image` and `featured-image_title` front available configuration options.