### PR TITLE
fix: change backend auth from git-gateway to github

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,8 +2,10 @@
 # https://www.netlifycms.org/docs/configuration-options/
 
 backend:
-  name: git-gateway # Netlify’s Git Gateway connects to Git provider’s API
+  # name: git-gateway # Netlify’s Git Gateway connects to Git provider’s API
+  name: github
   repo: redhat-developer/design-manual
+  open_authoring: true
   branch: main # Branch to update (main by default)
   squash_merges: true
   commit_messages:

--- a/admin/index.html
+++ b/admin/index.html
@@ -11,7 +11,23 @@
     </script>
   </head>
   <body>
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <!-- <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script> -->
+    <script src="https://unpkg.com/netlify-auth-providers"></script>
+
+    <script>
+      $(function() {
+        $("#login").on("click", function(e) {
+          e.preventDefault();
+          var authenticator = new netlify.default ({});
+          authenticator.authenticate({provider:"github", scope: "user"}, function(err, data) {
+            if (err) {
+              return $("#output").text("Error Authenticating with GitHub: " + err);
+            }
+            $("#output").text("Authenticated with GitHub. Access Token: " + data.token);
+          });
+        });
+      });
+    </script>
     <script>
     const previewStyles = `
       html,
@@ -55,5 +71,8 @@
     //   }
     // });
       </script>
+      <h1>GitHub Auth Demo:</h1>
+      <p><a href="#" id="login">Authenticate</a></p>
+      <p id="output"></p>
   </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -9,9 +9,7 @@
     <script>
       CMS.registerPreviewStyle("/admin.css");
     </script>
-  </head>
-  <body>
-    <!-- <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script> -->
+    <script src="https://code.jquery.com/jquery-1.11.2.js"></script>
     <script src="https://unpkg.com/netlify-auth-providers"></script>
 
     <script>
@@ -28,6 +26,9 @@
         });
       });
     </script>
+  </head>
+  <body>
+    <!-- <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script> -->
     <script>
     const previewStyles = `
       html,


### PR DESCRIPTION
## Description of changes
Change the CMS backend from `git-gateway` to `github` and enable **Open Authoring** in order to accept contributions (PRs) from those outside of the org.