### PR TITLE
fix: Add Topic Nav component example

### DIFF
--- a/_data/components.yml
+++ b/_data/components.yml
@@ -67,6 +67,9 @@ toc:
   - page: Toolbar
     url: /components/toolbar
     status: unreleased
+  - page: Topic Nav
+    url: /components/topic-nav
+    status: unreleased
   - page: Two Column Layout Hero
     url: /components/two-col-hero-layout
   - page: Video Hero

--- a/pages/components/topic-nav/default.md
+++ b/pages/components/topic-nav/default.md
@@ -1,0 +1,55 @@
+<div class="topic-navigation__wrapper">
+  <div class="topic-navigation">
+    <button class="topic-navigation__scroll-button m-left" aria-label="scroll-left">
+      <i class="fa fa-angle-left"></i>
+    </button>
+    <div class="topic-navigation-block">
+      <a href="#">
+        <div>
+          <i class="fas fa-arrow-up"></i>
+          <span class="topic-navigation-label">Code</span>
+          <h3>flex-wrap</h3>
+        </div>
+      </a>
+    </div>
+    <div class="topic-navigation-block">
+      <a href="#">
+        <div>
+          <i class="fas fa-arrow-up"></i>
+          <span class="topic-navigation-label">Article</span>
+          <h3>flex-direction: column</h3>
+        </div>
+      </a>
+    </div>
+    <div class="topic-navigation-block">
+      <a href="#">
+        <div>
+          <i class="fas fa-arrow-up"></i>
+          <span class="topic-navigation-label">Design</span>
+          <h3>grid-template-columns: repeat(150px, 1fr);</h3>
+        </div>
+      </a>
+    </div>
+    <div class="topic-navigation-block">
+      <a href="#">
+        <div>
+          <i class="fas fa-arrow-down"></i>
+          <span class="topic-navigation-label">Blog</span>
+          <h3>Topic 4</h3>
+        </div>
+      </a>
+    </div>
+    <div class="topic-navigation-block">
+      <a href="#">
+        <div>
+          <i class="fas fa-arrow-up"></i>
+          <span class="topic-navigation-label">Blog</span>
+          <h3>This is a long Topic 5</h3>
+        </div>
+      </a>
+    </div>
+    <button class="topic-navigation__scroll-button m-right" aria-label="scroll-right">
+      <i class="fa fa-angle-right"></i>
+    </button>
+  </div>
+</div>

--- a/pages/components/topic-nav/template.md
+++ b/pages/components/topic-nav/template.md
@@ -1,0 +1,101 @@
+---
+layout: develop
+category: develop
+title: Topic Nav
+active_nav: Components
+permalink: /components/topic-nav
+section: components
+status: unreleased
+custom_css: topic-nav
+custom_js: topic-nav
+intro_paragraph:
+---
+
+{% include code-snippets.html %}
+
+<h2 id="code">Code Snippets</h2>
+
+The Topic Navigation is designed to dynamically show the trending topics on the Developer site. At a maximum of six (6) items, the topic navigation is configured to show all of the items at a desktop (1440px wide) size, while using a horizontal scroll on smaller screens. The Topic Navigation is always placed below the main navigation.
+
+## Default Topic Nav
+{% include_relative default.md %}
+
+### Topic Nav Examples
+
+#### Default
+
+The default version of the Topic Navigation, designed to show whether an item is trending up or down (by the use of color-coded arrows), the type of content, and the title. Additional information (such as published date), are available on hover.
+
+<p
+  class="codepen"
+  data-height="165"
+  data-theme-id="dark"
+  data-default-tab="result"
+  data-user="mindreeper2420"
+  data-slug-hash="yLOrvro"
+  style="height: 165px;
+          box-sizing: border-box;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 2px solid;
+          margin: 1em 0;
+          padding: 1em;"
+  data-pen-title="New Topic Nav">
+  <span>See the Pen <a href="https://codepen.io/mindreeper2420/pen/yLOrvro">
+  New Topic Nav</a> by Adam Jolicoeur (<a href="https://codepen.io/mindreeper2420">@mindreeper2420</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>
+
+#### Simplified
+
+A simplified version of the Topic Navigation removes the 'type' of content and only shows the page title. An even simpler method removes the identifying arrows (up and down), replacing them with colored text (green for trending up, red for trending down).
+
+<p
+  class="codepen"
+  data-height="290"
+  data-theme-id="dark"
+  data-default-tab="result"
+  data-user="mindreeper2420"
+  data-slug-hash="QWNXPRZ"
+  style="height: 290px;
+          box-sizing: border-box;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 2px solid;
+          margin: 1em 0;
+          padding: 1em;"
+  data-pen-title="New Topic Nav (simplified)">
+  <span>See the Pen <a href="https://codepen.io/mindreeper2420/pen/QWNXPRZ">
+  New Topic Nav (simplified)</a> by Adam Jolicoeur (<a href="https://codepen.io/mindreeper2420">@mindreeper2420</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>
+
+#### Advanced
+
+The advanced version of the Topic Navigation takes the standard horizontal layout but, instead of allowing for a horizontal scroll, uses an expandable area to display more than six (6) items. When expanded, the topic navigation becomes a standard vertical list that can be scrolled vertically.
+
+<p
+  class="codepen"
+  data-height="265"
+  data-theme-id="dark"
+  data-default-tab="result"
+  data-user="mindreeper2420"
+  data-slug-hash="mdPZYrX"
+  style="height: 265px;
+          box-sizing: border-box;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 2px solid;
+          margin: 1em 0;
+          padding: 1em;"
+  data-pen-title="New Topic Nav (advanced)">
+  <span>See the Pen <a href="https://codepen.io/mindreeper2420/pen/mdPZYrX">
+  New Topic Nav (simplified)</a> by Adam Jolicoeur (<a href="https://codepen.io/mindreeper2420">@mindreeper2420</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/styles/custom/topic-nav.scss
+++ b/styles/custom/topic-nav.scss
@@ -1,0 +1,120 @@
+/* stylelint-disable */
+
+.topic-navigation__wrapper {
+  border-bottom: 1px solid #ddd;
+  box-shadow: 0 5px 5px 0 #ddd;
+}
+
+.topic-navigation {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: flex-start;
+  max-width: 1440px;
+  height: 55px;
+  margin: 0 auto;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  gap: 15px;
+
+  @media screen and (max-width: 960px) {
+    flex-direction: column;
+    max-width: 960px;
+    gap: 15px;
+  }
+}
+
+.topic-navigation-block {
+  align-self: center;
+  text-align: center;
+
+  &:first-of-type {
+    padding-left: 45px;
+  }
+
+  &:last-of-type {
+    padding-right: 45px;
+  }
+
+  a {
+    color: #151515;
+
+    &:hover {
+      color: lighten(#151515, 45%);
+      text-decoration: none;
+    }
+  }
+
+  div {
+    display: grid;
+    grid-template-columns: auto;
+    justify-content: center;
+  }
+
+  div i {
+    grid-column-start: 1;
+    grid-row-start: 2;
+    align-self: center;
+    padding-right: 6px;
+  }
+
+  div span {
+    grid-column-start: 1;
+    grid-column: span 2;
+  }
+
+  div h3 {
+    grid-column-start: 2;
+    grid-row-start: 2;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 1.2rem;
+  }
+  div h3:not(:first-child) {
+      margin-top: 0;
+  }
+
+  div i.fa-arrow-down {
+    color: #ff0000;
+  }
+
+  div i.fa-arrow-up {
+    color: #008000;
+  }
+
+  .topic-navigation-label {
+    font-size: .85em;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+  }
+}
+
+.topic-navigation__scroll-button {
+  top: 0;
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 55px;
+  padding: 0 8px;
+  background: rgba(256, 256, 256, 1);
+  border: 1px solid transparent;
+  opacity: 1;
+
+  @media screen and (max-width: 1439px) {
+    position: fixed;
+  }
+}
+
+.m-right {
+  right: 0;
+  border-left-color: #ddd;
+}
+
+.m-left {
+  left: 0;
+  border-right-color: #ddd;
+}
+
+/* stylelint-enable */


### PR DESCRIPTION
## Description of changes
Add an example of the new Topic Navigation, to be used in conjunction with the updated universal navigation.

This new component page includes multiple CodePens, allowing for examples to be updated without updating the site.

fixes issue #196 