### PR TITLE
fix: move Tables example CSS to separate file

### DIFF
--- a/pages/components/tables/template.md
+++ b/pages/components/tables/template.md
@@ -6,62 +6,12 @@ active_nav: Components
 permalink: /components/tables
 section: components
 status: unreleased
+custom_css: tables
 custom_js: code-snippets
 intro_paragraph:
 ---
 <!-- remove this style block once code is merged to developers.redhat.com -->
-<style>
-  @media screen and (max-width: 768px) {
-    .pf-c-table__toggle .pf-c-button.pf-m-expanded>* {
-      transform: rotate(0) !important;
-    }
-  }
-  @media screen and (max-width: 768px) and (min-width: 320px) {
-    .rhd-c-table .rhd-m-register {
-      justify-self: baseline;
-    }
-  }
-  .rhd-c-table {
-    --pf-c-table__expandable-row--before--BackgroundColor: #ee0000;
-  }
-  .rhd-c-table .pf-c-button:hover:after {
-    border-color: transparent;
-  }
-  .rhd-c-table .rhd-m-register {
-    padding-left: 0;
-  }
-  .rhd-c-table .pf-c-table__sort.pf-m-selected .pf-c-button:hover {
-    color: var(--pf-c-button--m-link--hover--Color);
-  }
-  .rhd-c-table .pf-c-table__sort.pf-m-selected .pf-c-table__sort-indicator:hover {
-    color: var(--pf-c-button--m-link--hover--Color);
-  }
-  .rhd-m-nested-table thead tr {
-    border-bottom: 0 !important;
-  }
-  .rhd-m-nested-table thead tr th {
-    padding-bottom: 8px;
-  }
-  .rhd-m-nested-table tbody tr th {
-    padding-top: 8px;
-  }
-  .rhd-m-nested-table tbody tr td {
-    padding-top: 8px;
-  }
-  .rhd-m-nested-table thead tr>*:first-child {
-    padding-left: 0;
-  }
-  .rhd-m-nested-table tbody tr>*:first-child {
-    padding-left: 0;
-  }
-  .pf-c-table .pf-c-table__expandable-row-content h6 {
-    font-size: 14px;
-    font-weight: 600;
-  }
-  .pf-c-table .pf-c-table__expandable-row-content p {
-    font-size: 14px;
-  }
-</style>
+
 {% include code-snippets.html %}
 
 ## Default table

--- a/styles/custom/tables.scss
+++ b/styles/custom/tables.scss
@@ -1,0 +1,52 @@
+/* stylelint-disable */
+@media screen and (max-width: 768px) {
+    .pf-c-table__toggle .pf-c-button.pf-m-expanded>* {
+      transform: rotate(0) !important;
+    }
+  }
+  @media screen and (max-width: 768px) and (min-width: 320px) {
+    .rhd-c-table .rhd-m-register {
+      justify-self: baseline;
+    }
+  }
+  .rhd-c-table {
+    --pf-c-table__expandable-row--before--BackgroundColor: #ee0000;
+  }
+  .rhd-c-table .pf-c-button:hover:after {
+    border-color: transparent;
+  }
+  .rhd-c-table .rhd-m-register {
+    padding-left: 0;
+  }
+  .rhd-c-table .pf-c-table__sort.pf-m-selected .pf-c-button:hover {
+    color: var(--pf-c-button--m-link--hover--Color);
+  }
+  .rhd-c-table .pf-c-table__sort.pf-m-selected .pf-c-table__sort-indicator:hover {
+    color: var(--pf-c-button--m-link--hover--Color);
+  }
+  .rhd-m-nested-table thead tr {
+    border-bottom: 0 !important;
+  }
+  .rhd-m-nested-table thead tr th {
+    padding-bottom: 8px;
+  }
+  .rhd-m-nested-table tbody tr th {
+    padding-top: 8px;
+  }
+  .rhd-m-nested-table tbody tr td {
+    padding-top: 8px;
+  }
+  .rhd-m-nested-table thead tr>*:first-child {
+    padding-left: 0;
+  }
+  .rhd-m-nested-table tbody tr>*:first-child {
+    padding-left: 0;
+  }
+  .pf-c-table .pf-c-table__expandable-row-content h6 {
+    font-size: 14px;
+    font-weight: 600;
+  }
+  .pf-c-table .pf-c-table__expandable-row-content p {
+    font-size: 14px;
+  }
+  /* stylelint-enable */


### PR DESCRIPTION
## Description of changes
Move the example CSS for the Tables component to it's own CSS file (was inline). This will allow for easier cleanup/maintenance in the future, once Tables are a part of the Developer site's core styling.