### PR TITLE
fix: documentation updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-report.md
+++ b/.github/ISSUE_TEMPLATE/security-report.md
@@ -19,7 +19,7 @@ Security reports must include:
 
 - Design Manual version
 - Operating system and version (Windows, macOS, Linux+Distribution)
-- Node Version (i.e. 12.18.1)
+- Node Version (i.e. 12.18.4)
 - Ruby Version (i.e. 2.6.3)
 - Gem version
   - `gem "jekyll", "~> 3.8.7"`

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -38,14 +38,13 @@ github-actions:
   - .github/**
 CMS:
   - ./admin/**
-tools:
-  - _config.yml
-  - .grenrc.json
-  - .stylelintrc.json
 bundler:
   - Gemfile
   - Gemfile.lock
-build-improvements:
+build-tools:
+  - _config.yml
+  - .grenrc.json
+  - .stylelintrc.json
   - .travis.yml
   - gulpfile.js
   - netlify.toml

--- a/guides/BUILD_CONFIG.md
+++ b/guides/BUILD_CONFIG.md
@@ -10,22 +10,12 @@ The following are the GitHub Actions that are used in this project
 - Site Builder
 
 ### Publish a Release
-This step is made up of two actions: Updating the Changelog and Creating a release based off of an existing tag.
-
-**Update Changelog**
-- Action: [generate-changelog-action](https://github.com/marketplace/actions/generate-changelog-action)
-- Repo: [ScottBrenner/generate-changelog-action](https://github.com/ScottBrenner/generate-changelog-action)
-- Workflow: [github-tag-actions.yml](https://github.com/redhat-developer/design-manual/blob/main/.github/workflows/github-tag-actions.yml)
+This step is made up of two actions: Creating a release as a draft, and then self-publishing the draft.
 
 **Create a Release**
-- Action: [Create a Release](https://github.com/marketplace/actions/create-a-release)
-- Repo: [actions/create-release](https://github.com/actions/create-release)
-- Workflow: [github-tag-actions.yml](https://github.com/redhat-developer/design-manual/blob/main/.github/workflows/github-tag-actions.yml)
-
-### Automatically Merge a PR
-- Action: [Merge pull requests](https://github.com/marketplace/actions/merge-pull-requests)
-- Repo: [pascalgn/automerge-action](https://github.com/pascalgn/automerge-action)
-- Workflow: [automerge.yml](https://github.com/redhat-developer/design-manual/blob/main/.github/workflows/automerge.yml)
+- Action: [release-drafter](https://github.com/marketplace/actions/release-drafter)
+- Repo: [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)
+- Workflow: [release-drafter.yml](https://github.com/redhat-developer/design-manual/blob/main/.github/workflows/release-drafter.yml)
 
 ### Jekyll Site CI
 - Repo: [actions/starter-workflows](https://github.com/actions/starter-workflows/blob/3c3736f59805d1e4f838182263705f44fab9cf68/ci/jekyll.yml)

--- a/guides/DEFAULT_FRONTMATTER.md
+++ b/guides/DEFAULT_FRONTMATTER.md
@@ -1,14 +1,64 @@
 # Default Frontmatter
 
+Each section has a different default Frontmatter. See the guide below for details.
+
+**Develop**
 ```yaml
 ---
 layout: [ SELECT A LAYOUT]
-title: [ INSERT TITLE }
+category: [ DEFINE CATEGORY - DEFAULTS TO DEVELOP ]
+section: [ DEFINE PAGE SECTION - MATCHES LAYOUT]
+title: [ INSERT TITLE ]
 subtitle: [ OPTIONAL SUBTITLE ]
+nav: [ WHAT SIDENAV OPTION SHOULD BE HIGHLIGHTED WHEN A PAGE IS ACTIVE ]
 permalink: [ DEFINE YOUR PATH ]
+status: [ SET RELEASE STATUS - RELEASED, UNRELEASED, DEVELOPMENT ]
+intro_paragraph: [ OPTIONAL INTRODUCTORY PARAGRAPH - REMOVE IF NOT NEEDED ]
 custom_js: [ OPTIONAL CUSTOM JS ]
 custom_css: [ OPTIONAL CUSTOM CSS ]
+---
+```
+
+**Create**
+```yaml
+---
+layout: [ SELECT A LAYOUT]
+category: [ DEFINE CATEGORY - DEFAULTS TO DEVELOP ]
 section: [ DEFINE PAGE SECTION - MATCHES LAYOUT]
+permalink: [ DEFINE YOUR PATH ]
+title: [ INSERT TITLE ]
+nav: [ WHAT SIDENAV OPTION SHOULD BE HIGHLIGHTED WHEN A PAGE IS ACTIVE ]
+intro_paragraph: [ OPTIONAL INTRODUCTORY PARAGRAPH - REMOVE IF NOT NEEDED ]
+custom_js: [ OPTIONAL CUSTOM JS ]
+custom_css: [ OPTIONAL CUSTOM CSS ]
+---
+```
+
+**Assemblies**
+```yaml
+---
+layout: [ SELECT A LAYOUT]
+category: [ DEFINE CATEGORY - DEFAULTS TO DEVELOP ]
+section: [ DEFINE PAGE SECTION - MATCHES LAYOUT]
+title: [ INSERT TITLE ]
+nav: [ WHAT SIDENAV OPTION SHOULD BE HIGHLIGHTED WHEN A PAGE IS ACTIVE ]
+permalink: [ DEFINE YOUR PATH ]
+status: [ SET RELEASE STATUS - RELEASED, UNRELEASED, DEVELOPMENT ]
+youtube_video: [ FEATURED VIDEO FOR THE ASSEMBLY EXAMPLE ]
+video-title: [ TITLE FOR THE VIDEO ]
+intro_paragraph: [ OPTIONAL INTRODUCTORY PARAGRAPH - REMOVE IF NOT NEEDED ]
+---
+```
+
+**Layouts**
+```yaml
+---
+layout: [ SELECT A LAYOUT]
+category: [ DEFINE CATEGORY - DEFAULTS TO DEVELOP ]
+section: [ DEFINE PAGE SECTION - MATCHES LAYOUT]
+title: [ INSERT TITLE ]
+nav: [ WHAT SIDENAV OPTION SHOULD BE HIGHLIGHTED WHEN A PAGE IS ACTIVE ]
+permalink: [ DEFINE YOUR PATH ]
 intro_paragraph: [ OPTIONAL INTRODUCTORY PARAGRAPH - REMOVE IF NOT NEEDED ]
 ---
 ```

--- a/guides/DEVELOPMENT.MD
+++ b/guides/DEVELOPMENT.MD
@@ -9,10 +9,12 @@ Following the accepted Jekyll configurations, the Developer Manual directory is 
 ```bash
 /_data # Data files used for the navigations
 /_includes # Site includes
+    /quick-links # Quick links for the homepage
   | /sidenavs # Various side navigations for pages
 /_layouts # Site layouts
 /_posts
 /_sass
+/.github # GitHub config folder
 /admin # Netlify configuration directory
 /assets # Site specific images, JS files & font files
 /brand-assets # image assets for the Brand Team
@@ -29,7 +31,8 @@ Following the accepted Jekyll configurations, the Developer Manual directory is 
   | /pages
 /scripts # Various scripts for the site
 /styles # Styles for customizing the Design Manual
-  | /partials
+    /custom # Custom CSS files, loaded as defined in Frontmatter
+  | /partials # Breakout of CSS
   | main.scss # Pulls in Design Manual site specific styles
 ```
 
@@ -52,6 +55,7 @@ To view the site locally, navigate to [localhost:4000/design-manual/](http://loc
 
 Each page under is built using Jekyll Frontmatter. Due to the size and complexity of this site, we use multiple variations of the Frontmatter in order to properly sort and render the various examples and documentation.
 
+**simple example**
 ```markdown
 ---
 layout: pages

--- a/guides/GETTING-STARTED.MD
+++ b/guides/GETTING-STARTED.MD
@@ -30,4 +30,4 @@ For example, you might use a utility class to add additional spacing between ele
 
 ## Released vs Unreleased
 
-Our components, assemblies, and page examples are labelled with either a <span class="pf-c-label label-released">released</span> or <span class="pf-c-label label-unreleased">unreleased</span> marker, easily signifying their status on developers.redhat.com. Anything with the <span class="pf-c-label label-unreleased">unreleased</span> label should be considered a work-in-progress and not recommended for use in production.
+Our components, assemblies, and page examples are labelled with either **Unreleased** or **In Development**, signifying their status on developers.redhat.com. Anything with these labels should be considered a work-in-progress and not for use in production.

--- a/guides/LABELS.md
+++ b/guides/LABELS.md
@@ -7,7 +7,7 @@ Labels available for use in the repo.
 | blocked           | indicates that the item is blocked by something  |
 | brand-assets      | Changes to assets under the /brand-assets directory |
 | bug               | Something isn't working |
-| build-improvements | Improvements to the build - Netlify/Travis/GitHub |
+| build-tools       | Improvements to the build tools - Netlify/Travis/GitHub |
 | bundler           | Bundler related change or issue - used by automated processes |
 | CMS               | Updates/work to the CMS |
 | dependencies      | Pull requests that update a dependency file |
@@ -16,7 +16,7 @@ Labels available for use in the repo.
 | duplicate         | Duplicate issue or PR |
 | enhancement       | Updates to an existing feature or design |
 | feature           | Feture release - major version bump |
-| github-action     | GitHub Actions related change or issue - used by automated processes |
+| github-actions    | GitHub Actions related change or issue - used by automated processes |
 | good first issue  | Good for newcomers |
 | help wanted       | Extra attention is needed |
 | in progress       | PRs that are in progress and should not be merged |
@@ -31,6 +31,4 @@ Labels available for use in the repo.
 | question          | Further information is requested |
 | Ready to merge    | Pull request is ready to be merged |
 | security          | Denotes/Addresses a security issue or concern |
-| submodule-update  | Chagnes made to the RHDP theme |
-| tools             | |
 | wontfix           | This will not be worked on |


### PR DESCRIPTION
## Description of changes
Update documentation for the site. Includes notes on NodeJS LTS version bump, updates for Labeler, cleanup of the `build_config.md` file, expanded upon default Frontmatter configs per sections of the site, and more.
