### PR TITLE
fix: simplify meta descriptions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: Red Hat Developers Design Manual
 email: adamj@redhat.com
 description: >- # this means to ignore newlines until "baseurl:"
-  This guide will serve as a home base for the Red Hat Developer story, messaging, and visual brand language. It’s a place you can always return to when you have questions about how to best represent Red Hat Developer through messaging or visual elements.
+  This guide will serve as a home base for the Red Hat Developer story, messaging, and visual brand language.
 baseurl: "/design-manual" # change to GitHub project repo name i.e. redhat-developer/rhddx for GitHub pages w/no custom domain
 url: "https://redhat-developer.github.io/design-manual/"
 version: 2.46.0

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{ site.description }} | {{ page.intro_paragraph }}">
+  {% if page.intro_paragraph == '' %}
+    <meta name="description" content="{{ site.description }}">
+  {% elsif page.intro_paragraph != '' %}
+    <meta name="description" content="{{ page.intro_paragraph }}">
+  {% endif %}
   <meta name="theme-color" content="#ffffff">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <link async rel="stylesheet" href="https://developers.redhat.com/themes/custom/rhdp2/rhd-frontend/dist/css/rhd.css">


### PR DESCRIPTION
## Description of changes
- Simplify the meta description to either include the general site description or the introductory paragraph for a page.
- If there is no introductory paragraph, the general site description will be used.

fixes #209