### PR TITLE
fix: Update logo reference page

### DIFF
--- a/_data/design.yml
+++ b/_data/design.yml
@@ -3,7 +3,7 @@ toc:
     subfolderitems:
       - page: Story / Messaging
         url: /brand-assets/RHD_Story_Messaging/story-messaging
-      - page: Full Logos
+      - page: Logos
         url: /brand-assets/RHD_Full_Logo/full-logo
       - page: Typography
         url: /design/brand/typography

--- a/brand-assets/RHD_Full_Logo/full-logo.md
+++ b/brand-assets/RHD_Full_Logo/full-logo.md
@@ -3,53 +3,146 @@ layout: design
 category: design
 section: RHD Brand Elements
 permalink: brand-assets/RHD_Full_Logo/full-logo
-title: Full Logos
+title: Logos
 active_nav: RHD_Brand_Elements
 intro_paragraph: >
 
-active_header: Full Logos
-download_url: https://github.com/redhat-developer/design-manual/tree/site-demo/brand-assets/RHD_Full_Logo
-image1: NewRHDFullLogo_color.png
-image2: NewRHDFullLogo_color_white-wordmark.png
-image3: NewRHDFullLogo_4-color.png
-image4: NewRHDFullLogo_4-color_white-wordmark.png
-image5: NewRHDFullLogo_black.png
-image6: NewRHDFullLogo_white.png
+active_header: Logos
 ---
-
-<!-- ## {{ page.image1 }}
-  <img src="{{ page.image1 }}" alt="Image of {{ page.image1 }}">
-
-## {{ page.image2 }}
-  <img src="{{ page.image2 }}" alt="Image of {{ page.image2 }}">
-
-## {{ page.image3 }}
-  <img src="{{ page.image3 }}" alt="Image of {{ page.image3 }}">
-
-## {{ page.image4 }}
-  <img src="{{ page.image4 }}" alt="Image of {{ page.image4 }}">
-
-## {{ page.image5 }}
-  <img src="{{ page.image5 }}" alt="Image of {{ page.image5 }}">
-
-## {{ page.image6 }}
-  <img src="{{ page.image6 }}" alt="Image of {{ page.image6 }}"> -->
-
 
 ## Files
 _To download an image, right click on it and select 'Save Image As'_
 
-| Name | Usage | SVG | PNG |
-|:----|:----|----:|:----:|
-| Full Logo Full-Color | This is the primary version of the logo to be used on light or white backgrounds   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png" alt="Logo (SVG)" width="320"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png" alt="Logo (PNG)" width="320"></a>       |
-| Full Logo Full-Color (black background)   |This is the primary version of the logo to be used on dark gray or black backgrounds   | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png" alt="Logo (SVG)" width="320"></a></div>       | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png" alt="Logo (PNG)" width="320"></a></div>       |
-| Full Logo 4-color   |This version of the logo should only be used when printing limitations restrict the use of the full-color logo   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png" alt="Logo (SVG)" width="320"></a>       | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png" alt="Logo (PNG)" width="320"></a>       |
-| Full Logo 4-color (black background)   |This version of the logo should only be used when printing limitations restrict the use of the full-color logo   | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png" alt="Logo (SVG)" width="320"></a></div>       | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png" alt="Logo (PNG)" width="320"></a></div>       |
-| Full Logo Black   |This version of the logo should be used when printing in black and white (over a light background), or whenever the background competes with the full-color logo but is too light for the white version of the logo   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png" alt="Logo (SVG)" width="320"></a>       | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png" alt="Logo (PNG)" width="320"></a>       |
-| Full Logo White (black background)   |This version of the logo should be used when printing in black and white (over a dark background), or when the background color is the same as one of the colors in the full-color logo, or whenever the background competes with the full-color logo  | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png" alt="Logo (SVG)" width="320"></a></div>       | <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png" alt="Logo (PNG)" width="320"></a> </div>      |
-| Mark Full-Color |This is the primary version of the logo to be used on light or white backgrounds   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png" alt="Symbol (PNG)" width="160"></a> |
-| Mark Full-Color (black background) |This is the primary version of the logo to be used on dark gray or black backgrounds   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (PNG)" width="160"></a> |
-| Mark 4-color |This version of the logo should only be used when printing limitations restrict the use of the full-color logo   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png" alt="Symbol (PNG)" width="160"></a> |
-| Mark 4-color (black background) |This version of the logo should only be used when printing limitations restrict the use of the full-color logo   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (PNG)" width="160"></a> |
-| Mark White (red background) |This version of the logo should be used when printing in black and white (over a dark background), or when the background color is the same as one of the colors in the full-color logo, or whenever the background competes with the full-color logo  | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png" alt="Symbol (PNG)" width="160"></a> |
-| Mark Black |This version of the logo should be used when printing in black and white (over a light background), or whenever the background competes with the full-color logo but is too light for the white version of the logo   | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png" alt="Symbol (SVG)" width="160"></a> | <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png" alt="Symbol (PNG)" width="160"></a> |
+<table class="pf-c-table pf-m-grid-md" role="grid" aria-label="Red Hat Developer Font Family table" id="table-font-family">
+  <caption>The relationship between fonts give a brand its identity and its messages a voice. When used effectively, typography plays a critical role in establishing the tone of Red Hat Developer's brand expression. Our typography should follow the Red Hat parent brand guidelines.</caption>
+  <thead>
+    <tr role="row">
+      <th role="columnheader" scope="col">Name</th>
+      <th role="columnheader" scope="col">Usage</th>
+      <th role="columnheader" scope="col">SVG</th>
+      <th role="columnheader" scope="col">PNG</th>
+    </tr>
+  </thead>
+  <tbody role="rowgroup">
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo Full-Color</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This is the primary version of the logo to be used on light or white backgrounds</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png" alt="Logo (SVG)" width="320"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color.png" alt="Logo (PNG)" width="320"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo Full-Color (black background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This is the primary version of the logo to be used on dark gray or black backgrounds</td>
+      <td role="cell" data-label="SVG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png" alt="Logo (SVG)" width="320"></a></div>
+      </td>
+      <td role="cell" data-label="PNG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_color_white-wordmark.png" alt="Logo (PNG)" width="320"></a></div>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo 4-color</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should only be used when printing limitations restrict the use of the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png" alt="Logo (SVG)" width="320"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color.png" alt="Logo (PNG)" width="320"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo 4-color (black background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should only be used when printing limitations restrict the use of the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png" alt="Logo (SVG)" width="320"></a></div>
+      </td>
+      <td role="cell" data-label="PNG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_4-color_white-wordmark.png" alt="Logo (PNG)" width="320"></a></div>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo Black</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should be used when printing in black and white (over a light background), or whenever the background competes with the full-color logo but is too light for the white version of the logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png" alt="Logo (SVG)" width="320"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_black.png" alt="Logo (PNG)" width="320"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Full Logo White (black background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should be used when printing in black and white (over a dark background), or when the background color is the same as one of the colors in the full-color logo, or whenever the background competes with the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png" alt="Logo (SVG)" width="320"></a></div>
+      </td>
+      <td role="cell" data-label="PNG">
+        <div style="background-color:rgb(0, 0, 0); text-align:center; vertical-align: middle; padding: 5px;"><a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Full_Logo/NewRHDFullLogo_white.png" alt="Logo (PNG)" width="320"></a> </div>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark Full-Color</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This is the primary version of the logo to be used on light or white backgrounds</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark Full-Color (black background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This is the primary version of the logo to be used on dark gray or black backgrounds</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark 4-color</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should only be used when printing limitations restrict the use of the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_4-color_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark 4-color (black background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should only be used when printing limitations restrict the use of the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_color_black_bg_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark White (red background)</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should be used when printing in black and white (over a dark background), or when the background color is the same as one of the colors in the full-color logo, or whenever the background competes with the full-color logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_white_red_bg_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+    <tr role="row">
+      <td role="cell" data-label="Name" style="vertical-align: top; word-break: normal;">Mark Black</td>
+      <td role="cell" data-label="Usage" style="vertical-align: top;">This version of the logo should be used when printing in black and white (over a light background), or whenever the background competes with the full-color logo but is too light for the white version of the logo</td>
+      <td role="cell" data-label="SVG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.svg"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png" alt="Symbol (SVG)" width="160"></a>
+      </td>
+      <td role="cell" data-label="PNG">
+        <a href="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png"><img src="https://raw.githubusercontent.com/redhat-developer/design-manual/main/brand-assets/RHD_Mark/RHD_mark_black_RGB.png" alt="Symbol (PNG)" width="160"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/pages/design/color-palette.md
+++ b/pages/design/color-palette.md
@@ -1,14 +1,13 @@
 ---
 layout: design
 category: design
-section: Color Palette
+section: RHD Brand Elements
 permalink: /design/color-palette
 title: Color Palette
-active_nav: RHD Brand Elements
+active_nav: RHD_Brand_Elements
 intro_paragraph: >
 
-custom_js:
-custom_css:
+active_header: Color Palette
 ---
 
 | Name | HEX | RGB | CMYK | PMS | Sample |


### PR DESCRIPTION
## Description of changes
- Improve the **Logos** page (formerly **Full Logos**) layout with updated table layout
- Change the name of the page from **Full Logos** to **Logos** to better represent the page content

![image](https://user-images.githubusercontent.com/4032718/97460747-6dac1800-1913-11eb-9de2-307f7001517e.png)
